### PR TITLE
Correct sorting of AlphaNumerics

### DIFF
--- a/tablesorter/plugin.js
+++ b/tablesorter/plugin.js
@@ -67,8 +67,8 @@
 							if(!bText || 0 === bText.length) return 0;
 							else return 1;
 						if(!bText || 0 === bText.length) return -1;
-						if(order == 'desc') return bText.localeCompare(aText);
-						return aText.localeCompare(bText);
+						if(order == 'desc') return bText.localeCompare(aText, undefined, {numeric:true});
+						return aText.localeCompare(bText, undefined, {numeric:true});
 					});
 
 					for (i = 0; i < itemsArr.length; ++i) {


### PR DESCRIPTION
This adds support for correct sorting of numbers
without this patch: 1,10,11,2,3,...
with this patch: 1,2,3,...,10,11

From the specs:
> **numeric** - Whether numeric collation should be used, such that "1" < "2" < "10". Possible values are true and false; the default is false. This option can be set through an options property or through a Unicode extension key; if both are provided, the options property takes precedence. Implementations are not required to support this property.